### PR TITLE
Bump PyJWT version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2020.12.5
 chardet==4.0.0
 idna==2.10
-PyJWT==2.0.0
+PyJWT>=2.0.1
 requests==2.25.1
 urllib3==1.26.2
 uuid==1.30

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='setu',
-    version='0.5.3',
+    version='0.5.4',
     url='https://github.com/SetuHQ/setu-python-sdk',
     author='Setu',
     author_email='dev.support@setu.co',


### PR DESCRIPTION
PyJWT had a minor issue with returning string vs bytes on some systems, which was fixed in the latest release by explicit type cast. Hence force bumping this.